### PR TITLE
fix(backend): 監査ログのcontext canceledエラーを修正

### DIFF
--- a/backend/internal/middleware/audit_log.go
+++ b/backend/internal/middleware/audit_log.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -102,7 +103,11 @@ func AuditLogMiddleware(auditService service.AuditLogService, logger *zap.Logger
 
 		// 監査ログの記録
 		go func() {
+			// バックグラウンドコンテキストを作成
+			ctx := context.Background()
+			
 			if err := auditService.LogHTTPRequest(
+				ctx,
 				c,
 				userID.(uuid.UUID),
 				model.AuditActionType(action),

--- a/backend/internal/service/audit_log_service.go
+++ b/backend/internal/service/audit_log_service.go
@@ -18,7 +18,7 @@ import (
 // AuditLogService 監査ログサービスインターフェース
 type AuditLogService interface {
 	LogActivity(ctx context.Context, params LogActivityParams) error
-	LogHTTPRequest(c *gin.Context, userID uuid.UUID, action model.AuditActionType, resourceType model.ResourceType, resourceID *string, duration time.Duration) error
+	LogHTTPRequest(ctx context.Context, c *gin.Context, userID uuid.UUID, action model.AuditActionType, resourceType model.ResourceType, resourceID *string, duration time.Duration) error
 	GetAuditLogs(ctx context.Context, filters repository.AuditLogFilters) ([]*model.AuditLog, int64, error)
 	GetUserAuditLogs(ctx context.Context, userID uuid.UUID, page, limit int) ([]*model.AuditLog, error)
 	GetResourceAuditLogs(ctx context.Context, resourceType model.ResourceType, resourceID string, page, limit int) ([]*model.AuditLog, error)
@@ -119,7 +119,7 @@ func (s *auditLogService) LogActivity(ctx context.Context, params LogActivityPar
 }
 
 // LogHTTPRequest HTTPリクエストをログに記録
-func (s *auditLogService) LogHTTPRequest(c *gin.Context, userID uuid.UUID, action model.AuditActionType, resourceType model.ResourceType, resourceID *string, duration time.Duration) error {
+func (s *auditLogService) LogHTTPRequest(ctx context.Context, c *gin.Context, userID uuid.UUID, action model.AuditActionType, resourceType model.ResourceType, resourceID *string, duration time.Duration) error {
 	// 監査対象でない場合はスキップ
 	if !action.ShouldAudit() {
 		return nil
@@ -154,7 +154,8 @@ func (s *auditLogService) LogHTTPRequest(c *gin.Context, userID uuid.UUID, actio
 		params.ErrorMessage = &errorMsg
 	}
 
-	return s.LogActivity(c.Request.Context(), params)
+	// バックグラウンドコンテキストを使用してログを記録
+	return s.LogActivity(ctx, params)
 }
 
 // GetAuditLogs 監査ログを取得

--- a/backend/internal/service/audit_log_service_test.go
+++ b/backend/internal/service/audit_log_service_test.go
@@ -1,0 +1,266 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/duesk/monstera/internal/model"
+	"github.com/duesk/monstera/internal/repository"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// MockAuditLogRepository is a mock implementation of AuditLogRepository
+type MockAuditLogRepository struct {
+	mock.Mock
+}
+
+func (m *MockAuditLogRepository) Create(ctx context.Context, auditLog *model.AuditLog) error {
+	args := m.Called(ctx, auditLog)
+	return args.Error(0)
+}
+
+func (m *MockAuditLogRepository) GetByID(ctx context.Context, id uuid.UUID) (*model.AuditLog, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.AuditLog), args.Error(1)
+}
+
+func (m *MockAuditLogRepository) GetByFilters(ctx context.Context, filters repository.AuditLogFilters) ([]*model.AuditLog, int64, error) {
+	args := m.Called(ctx, filters)
+	return args.Get(0).([]*model.AuditLog), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockAuditLogRepository) GetByUserID(ctx context.Context, userID uuid.UUID, limit int, offset int) ([]*model.AuditLog, error) {
+	args := m.Called(ctx, userID, limit, offset)
+	return args.Get(0).([]*model.AuditLog), args.Error(1)
+}
+
+func (m *MockAuditLogRepository) GetByResourceID(ctx context.Context, resourceType model.ResourceType, resourceID string, limit int, offset int) ([]*model.AuditLog, error) {
+	args := m.Called(ctx, resourceType, resourceID, limit, offset)
+	return args.Get(0).([]*model.AuditLog), args.Error(1)
+}
+
+func (m *MockAuditLogRepository) GetSuspiciousActivities(ctx context.Context, filters repository.SuspiciousActivityFilters) ([]*repository.SuspiciousActivity, error) {
+	args := m.Called(ctx, filters)
+	return args.Get(0).([]*repository.SuspiciousActivity), args.Error(1)
+}
+
+func (m *MockAuditLogRepository) DeleteOldLogs(ctx context.Context, retentionDays int) (int64, error) {
+	args := m.Called(ctx, retentionDays)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func TestLogHTTPRequest_Success(t *testing.T) {
+	// Setup
+	mockRepo := new(MockAuditLogRepository)
+	logger := zap.NewNop()
+	service := NewAuditLogService(&gorm.DB{}, logger, mockRepo)
+
+	// Create test context
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	
+	// Setup request
+	c.Request = httptest.NewRequest("GET", "/api/v1/notifications", nil)
+	c.Request.Header.Set("User-Agent", "TestAgent")
+	c.Request.Header.Set("X-Forwarded-For", "192.168.1.1")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	// Setup expectations
+	userID := uuid.New()
+	action := model.AuditActionType("NOTIFICATION_VIEW")
+	resourceType := model.ResourceType("NOTIFICATION")
+	duration := 20 * time.Millisecond
+
+	// Mock expectation
+	mockRepo.On("Create", mock.MatchedBy(func(ctx context.Context) bool {
+		// Verify that context is not the request context
+		select {
+		case <-ctx.Done():
+			return false
+		default:
+			return true
+		}
+	}), mock.MatchedBy(func(log *model.AuditLog) bool {
+		return log.UserID == userID &&
+			log.Action == string(action) &&
+			log.ResourceType == string(resourceType) &&
+			log.Method == "GET" &&
+			log.Path == "/api/v1/notifications" &&
+			log.StatusCode == 200 &&
+			*log.IPAddress == "192.168.1.1" &&
+			*log.UserAgent == "TestAgent"
+	})).Return(nil)
+
+	// Execute
+	ctx := context.Background()
+	err := service.LogHTTPRequest(ctx, c, userID, action, resourceType, nil, duration)
+
+	// Assert
+	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestLogHTTPRequest_WithCanceledContext(t *testing.T) {
+	// Setup
+	mockRepo := new(MockAuditLogRepository)
+	logger := zap.NewNop()
+	service := NewAuditLogService(&gorm.DB{}, logger, mockRepo)
+
+	// Create test context
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	
+	// Setup request
+	c.Request = httptest.NewRequest("GET", "/api/v1/notifications", nil)
+	c.Request.Header.Set("User-Agent", "TestAgent")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	// Setup expectations
+	userID := uuid.New()
+	action := model.AuditActionType("NOTIFICATION_VIEW")
+	resourceType := model.ResourceType("NOTIFICATION")
+	duration := 20 * time.Millisecond
+
+	// Create a canceled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Mock expectation - should still be called with the canceled context
+	mockRepo.On("Create", mock.Anything, mock.Anything).Return(context.Canceled)
+
+	// Execute
+	err := service.LogHTTPRequest(ctx, c, userID, action, resourceType, nil, duration)
+
+	// Assert - should return context.Canceled error
+	assert.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestLogHTTPRequest_SkipNonAuditableAction(t *testing.T) {
+	// Setup
+	mockRepo := new(MockAuditLogRepository)
+	logger := zap.NewNop()
+	service := NewAuditLogService(&gorm.DB{}, logger, mockRepo)
+
+	// Create test context
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	
+	// Setup request
+	c.Request = httptest.NewRequest("GET", "/api/v1/health", nil)
+
+	// Setup expectations with a non-auditable action
+	userID := uuid.New()
+	action := model.AuditActionType("HEALTH_CHECK") // Assume this is not auditable
+	resourceType := model.ResourceType("SYSTEM")
+	duration := 5 * time.Millisecond
+
+	// No repository calls should be made
+	// (no mock expectations set)
+
+	// Execute
+	ctx := context.Background()
+	err := service.LogHTTPRequest(ctx, c, userID, action, resourceType, nil, duration)
+
+	// Assert
+	assert.NoError(t, err)
+	mockRepo.AssertNotCalled(t, "Create", mock.Anything, mock.Anything)
+}
+
+func TestLogHTTPRequest_WithRequestBody(t *testing.T) {
+	// Setup
+	mockRepo := new(MockAuditLogRepository)
+	logger := zap.NewNop()
+	service := NewAuditLogService(&gorm.DB{}, logger, mockRepo)
+
+	// Create test context
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	
+	// Setup POST request
+	c.Request = httptest.NewRequest("POST", "/api/v1/users", nil)
+	c.Request.Header.Set("User-Agent", "TestAgent")
+	c.Writer.WriteHeader(http.StatusCreated)
+	
+	// Set request body in context
+	requestBody := map[string]interface{}{"name": "Test User", "email": "test@example.com"}
+	c.Set("request_body", requestBody)
+
+	// Setup expectations
+	userID := uuid.New()
+	action := model.AuditActionType("USER_CREATE")
+	resourceType := model.ResourceType("USER")
+	resourceID := "new-user-id"
+	duration := 50 * time.Millisecond
+
+	// Mock expectation
+	mockRepo.On("Create", mock.Anything, mock.MatchedBy(func(log *model.AuditLog) bool {
+		return log.RequestBody != nil && *log.RequestBody != ""
+	})).Return(nil)
+
+	// Execute
+	ctx := context.Background()
+	err := service.LogHTTPRequest(ctx, c, userID, action, resourceType, &resourceID, duration)
+
+	// Assert
+	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestLogHTTPRequest_WithError(t *testing.T) {
+	// Setup
+	mockRepo := new(MockAuditLogRepository)
+	logger := zap.NewNop()
+	service := NewAuditLogService(&gorm.DB{}, logger, mockRepo)
+
+	// Create test context
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	
+	// Setup request
+	c.Request = httptest.NewRequest("POST", "/api/v1/login", nil)
+	c.Writer.WriteHeader(http.StatusUnauthorized)
+	
+	// Add error to context
+	c.Errors = append(c.Errors, &gin.Error{
+		Err:  assert.AnError,
+		Type: gin.ErrorTypePublic,
+		Meta: "Invalid credentials",
+	})
+
+	// Setup expectations
+	userID := uuid.Nil // Failed login
+	action := model.AuditActionType("SESSION_LOGIN")
+	resourceType := model.ResourceType("SESSION")
+	duration := 10 * time.Millisecond
+
+	// Mock expectation
+	mockRepo.On("Create", mock.Anything, mock.MatchedBy(func(log *model.AuditLog) bool {
+		return log.ErrorMessage != nil && *log.ErrorMessage != ""
+	})).Return(nil)
+
+	// Execute
+	ctx := context.Background()
+	err := service.LogHTTPRequest(ctx, c, userID, action, resourceType, nil, duration)
+
+	// Assert
+	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
監査ログ記録時に発生している`context canceled`エラーを修正しました。

## 問題
HTTPレスポンス返却後にgoroutineで監査ログを記録する際、元のリクエストコンテキストがキャンセルされているため、データベース操作でエラーが発生していました。

## 変更内容
- [x] ミドルウェアでバックグラウンドコンテキストを作成
- [x] サービスインターフェースを更新してコンテキストを受け取るように変更
- [x] 単体テストを追加

## 技術的詳細
### 修正前
```go
go func() {
    if err := auditService.LogHTTPRequest(
        c,  // HTTPリクエストのGinコンテキスト
        userID.(uuid.UUID),
        // ...
    ); err != nil {
        // context canceled エラーが発生
    }
}()
```

### 修正後
```go
go func() {
    ctx := context.Background()  // 新しいコンテキストを作成
    if err := auditService.LogHTTPRequest(
        ctx,
        c,
        userID.(uuid.UUID),
        // ...
    ); err != nil {
        // エラーが解消される
    }
}()
```

## テスト
- [x] 単体テスト追加
- [ ] 統合テスト実施
- [ ] 手動テスト実施

## 確認項目
- [x] コーディング規約に準拠
- [x] エラーハンドリング実装
- [x] 既存機能への影響なし

## 関連Issue
- なし

## 関連ドキュメント
- 調査結果: `docs/investigate/investigate_20250713_153253.md`
- 実装計画: `docs/plan/plan_20250713_155631.md`