### PR TITLE
fix(frontend): ActiveRoleProviderエラーを修正 #15

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Providers } from './providers';
 import "./globals.css";
 
 const geistSans = Geist({
@@ -25,7 +26,9 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        {children}
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
   );


### PR DESCRIPTION
## 概要
ダッシュボード画面で発生していた`Error: useActiveRole must be used within an ActiveRoleProvider`エラーを修正しました。

## 変更内容
- [x] root layout (`src/app/layout.tsx`) にProvidersコンポーネントを追加
- [x] ActiveRoleProviderが正しく初期化されるように修正
- [x] ダッシュボード画面でのエラーを解消

## 技術詳細
### 根本原因
- `useActiveRole`フックが呼び出されているが、`ActiveRoleProvider`が初期化されていない
- root layoutファイルで`Providers`コンポーネントが使用されていない

### 修正内容
```typescript
// src/app/layout.tsx
import { Providers } from './providers';

export default function RootLayout({ children }: { children: React.ReactNode }) {
  return (
    <html lang="en">
      <body className={`${geistSans.variable} ${geistMono.variable}`}>
        <Providers>
          {children}
        </Providers>
      </body>
    </html>
  );
}
```

### プロバイダー階層
- AuthContext → ActiveRoleProvider → QueryErrorBoundary
- 全てのContextプロバイダーが適切に初期化される

## テスト
- [x] ビルドテスト実施（Next.js build success）
- [x] 開発環境動作確認（npm run dev success）
- [x] TypeScript型チェック
- [x] 基本動作確認（エラー解消）

## 確認事項
- [x] コーディング規約に準拠
- [x] エラーハンドリング実装（既存の枠組みを活用）
- [x] パフォーマンスへの影響を考慮（影響なし）
- [x] セキュリティへの影響を考慮（影響なし）

## 関連ドキュメント
- `docs/investigate/investigate_20250717_182439.md` - 詳細調査報告
- `docs/plan/plan_20250717_183136.md` - 実装計画書

🤖 Generated with [Claude Code](https://claude.ai/code)