### PR TITLE
[WIP] fix(frontend): ユーザーアイコン「？」表示問題を修正

### DIFF
--- a/frontend/src/lib/api/auth/index.ts
+++ b/frontend/src/lib/api/auth/index.ts
@@ -14,21 +14,15 @@ import {
 import { 
   setAuthState,
   clearAuthState,
-  removeUser
+  removeUser,
+  convertToLocalUser,
+  setUser as setLocalUser
 } from '@/utils/auth';
 import { DebugLogger } from '@/lib/debug/logger';
 
 // 認証エラーが発生したページのパスを保存するキー
 const AUTH_ERROR_PAGE_KEY = 'auth_error_from_page';
 
-/**
- * APIから取得したユーザー情報をローカルストレージに保存
- */
-const setUser = (user: any): void => {
-  if (typeof window !== 'undefined') {
-    localStorage.setItem('user', JSON.stringify(user));
-  }
-};
 
 /**
  * JWTログイン処理
@@ -71,7 +65,8 @@ export const login = async (credentials: LoginRequest): Promise<LoginResponse> =
       
       // ユーザー情報をローカルストレージに保存
       if (response.data.user) {
-        setUser(response.data.user);
+        const localUser = convertToLocalUser(response.data.user);
+        setLocalUser(localUser);
       } else {
         DebugLogger.apiError({
           category: 'JWT認証',
@@ -155,7 +150,8 @@ export const refreshToken = async (): Promise<RefreshTokenResponse> => {
       
       // ユーザー情報が含まれていれば更新
       if (response.data.user) {
-        setUser(response.data.user);
+        const localUser = convertToLocalUser(response.data.user);
+        setLocalUser(localUser);
       }
     }
     


### PR DESCRIPTION
## 概要
ログイン成功後にユーザーアイコンが「？」のまま表示される問題を修正

## 変更内容
- [x] ローカルストレージキーの不整合を修正（'user' → 'monstera_user'）
- [x] 重複するsetUser関数を削除
- [x] 統一されたデータ変換処理（convertToLocalUser）を適用
- [x] ログイン時とリフレッシュトークン時の保存処理を統一

## 関連Issue
- 問題: ユーザーアイコンが「？」表示される不具合

## 実装状況
- [x] 基本実装
- [ ] テスト追加
- [ ] ドキュメント更新
- [ ] レビュー対応

## テスト
- [ ] 手動テスト: ログイン→アイコン確認→リフレッシュ確認
- [ ] 統合テスト実施
- [ ] ローカルストレージ確認

## 確認事項
- [x] コーディング規約に準拠
- [x] エラーハンドリング実装
- [x] パフォーマンスへの影響を考慮
- [x] セキュリティへの影響を考慮

## レビュー依頼事項
- ローカルストレージキーの統一化
- データ変換処理の妥当性

## デプロイ時の注意
- 既存ログイン済みユーザーは再ログインが必要（一時的）