### PR TITLE
[Fix] 経費申請APIの401認証エラーを修正

### DIFF
--- a/frontend/src/lib/api/expense.ts
+++ b/frontend/src/lib/api/expense.ts
@@ -169,17 +169,9 @@ async function apiRequest<T>(
       'Content-Type': 'application/json',
       ...options.headers,
     },
+    credentials: 'include', // Cookie認証を使用
     ...options,
   };
-
-  // 認証トークンがある場合は追加
-  const token = localStorage.getItem('accessToken');
-  if (token) {
-    defaultOptions.headers = {
-      ...defaultOptions.headers,
-      Authorization: `Bearer ${token}`,
-    };
-  }
 
   try {
     const response = await fetch(url, defaultOptions);
@@ -304,9 +296,7 @@ export async function uploadReceipts(data: ReceiptUploadData): Promise<ReceiptUp
   const response = await fetch(`${API_BASE_URL}${EXPENSE_API_ENDPOINTS.RECEIPTS}`, {
     method: 'POST',
     body: formData,
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-    },
+    credentials: 'include', // Cookie認証を使用
   });
 
   if (!response.ok) {
@@ -342,9 +332,7 @@ export async function generateExpenseReport(params: ExpenseSearchParams & { form
 
   const endpoint = `${EXPENSE_API_ENDPOINTS.REPORTS}?${searchParams.toString()}`;
   const response = await fetch(`${API_BASE_URL}${endpoint}`, {
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
-    },
+    credentials: 'include', // Cookie認証を使用
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## 概要
経費申請ページアクセス時に発生する401認証エラーを修正しました。

## 問題
- 経費申請ページで`HTTP Error: 401`が発生
- 原因: localStorage認証とCookie認証の不整合

## 修正内容
### フェーズ1実装（このPR）
- ✅ apiRequest関数: localStorage参照を削除し、`credentials: 'include'`を追加
- ✅ uploadReceipts関数: 同上の修正
- ✅ generateExpenseReport関数: 同上の修正

## 変更内容
```diff
- Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
+ credentials: 'include', // Cookie認証を使用
```

## テスト方法
1. 開発環境でログイン
2. 経費申請ページ（/expenses）にアクセス
3. 一覧が正常に表示されることを確認
4. 経費申請の作成・更新・削除が動作することを確認
5. ファイルアップロード機能が動作することを確認

## 今後の対応
フェーズ2として、expense.tsの全面的なリファクタリング（axiosへの移行）を別途実施予定です。

## 関連
- Issue: #43
- 調査報告: `docs/investigate/investigate_20250724_172100.md`
- 実装計画: `docs/plan/plan_20250724_173500.md`