### PR TITLE
fix(frontend): 経費カテゴリAPIレスポンスの処理を修正

### DIFF
--- a/docs/investigate/investigate_20250725_140500.md
+++ b/docs/investigate/investigate_20250725_140500.md
@@ -1,0 +1,178 @@
+# 経費申請新規作成画面のcategories.filterエラー調査結果
+
+## 調査日時
+2025-07-25 14:05:00
+
+## 調査概要
+経費申請の新規作成画面で「TypeError: categories.filter is not a function」エラーが発生している問題の原因を調査。
+
+## エラー内容
+```
+error-boundary-callbacks.ts:80 TypeError: categories.filter is not a function
+    at useCategories.useMemo[activeCategories] (useCategories.ts:91:23)
+    at useCategories (useCategories.ts:89:34)
+    at ExpenseForm (ExpenseForm.tsx:60:87)
+```
+
+## 調査手順
+
+### 1. エラー発生箇所の特定
+**ファイル**: `/frontend/src/hooks/expense/useCategories.ts`
+**行番号**: 91行目
+```typescript
+const activeCategories = useMemo(() => {
+  if (!categories) return [];
+  return categories.filter(category => category.isActive);  // ここでエラー
+}, [categories]);
+```
+
+### 2. APIレスポンスの確認
+実際のAPIレスポンスを確認した結果：
+```json
+{
+  "data": [
+    {
+      "id": "0961ecdf-f610-402c-9bd7-23e3e26af2ae",
+      "code": "transport",
+      "name": "旅費交通費",
+      "requires_details": false,
+      "is_active": true,
+      "display_order": 1
+    },
+    // ... 他のカテゴリ
+  ]
+}
+```
+
+### 3. 関連コードの分析
+
+#### バックエンドのレスポンス形式
+**ファイル**: `/backend/internal/handler/expense_handler.go`
+```go
+c.JSON(http.StatusOK, gin.H{"data": response})
+```
+バックエンドは`{ data: [...] }`形式でレスポンスを返している。
+
+#### フロントエンドのAPI呼び出し
+**ファイル**: `/frontend/src/lib/api/expense.ts`
+```typescript
+export async function getExpenseCategories(signal?: AbortSignal): Promise<ExpenseCategory[]> {
+  return apiRequest<ExpenseCategory[]>(EXPENSE_API_ENDPOINTS.CATEGORIES, { signal });
+}
+```
+
+#### APIリクエスト関数
+**ファイル**: `/frontend/src/lib/api/index.ts`
+```typescript
+export const apiRequest = async <T>(
+  method: string,
+  url: string,
+  options: ApiClientOptions = {}
+): Promise<T> => {
+  // ...
+  return response.data;  // axiosのresponse.dataを返す
+}
+```
+
+## 根本原因
+
+**データ型の不一致**が原因：
+1. バックエンドは`{ data: ExpenseCategory[] }`形式でレスポンスを返す
+2. `apiRequest`はその全体（オブジェクト）を返す
+3. `getExpenseCategories`の戻り値の型定義は`ExpenseCategory[]`（配列）
+4. `useCategories`では`categories`を配列として扱おうとするが、実際はオブジェクト
+5. オブジェクトに`filter`メソッドは存在しないためエラーが発生
+
+## 影響範囲
+
+1. **直接的な影響**
+   - 経費申請新規作成画面が動作しない
+   - 経費申請編集画面も同様に動作しない可能性が高い
+   - カテゴリ選択ができない
+
+2. **潜在的な影響**
+   - 他のAPIエンドポイントでも同様の問題が発生している可能性
+   - 統一されていないレスポンス形式による混乱
+
+## 解決方針
+
+### 推奨解決策：フロントエンド側の修正
+
+#### 案1: apiRequest関数の改修（推奨）
+```typescript
+// apiRequest関数で{ data: T }形式のレスポンスを自動的に処理
+export const apiRequest = async <T>(
+  url: string,
+  options: ApiClientOptions = {}
+): Promise<T> => {
+  const response = await client.request({ ... });
+  // レスポンスがdataプロパティを持つ場合は自動的に展開
+  if (response.data && typeof response.data === 'object' && 'data' in response.data) {
+    return response.data.data;
+  }
+  return response.data;
+};
+```
+
+#### 案2: getExpenseCategories関数の修正
+```typescript
+export async function getExpenseCategories(signal?: AbortSignal): Promise<ExpenseCategory[]> {
+  const response = await apiRequest<{ data: ExpenseCategory[] }>(EXPENSE_API_ENDPOINTS.CATEGORIES, { signal });
+  return response.data;
+}
+```
+
+#### 案3: useCategories内での処理
+```typescript
+const categories = data?.data || data || [];
+```
+
+### 代替案：バックエンド側の修正（非推奨）
+バックエンドのレスポンス形式を変更することも可能だが、既存のAPIとの整合性を保つ必要があるため推奨しない。
+
+## 技術的制約
+
+1. **TypeScript型定義の不整合**
+   - 実際のデータ構造と型定義が一致していない
+   - コンパイル時にエラーが検出されない
+
+2. **API設計の不統一**
+   - 一部のエンドポイントは`{ data: [...] }`形式
+   - 他のエンドポイントは配列を直接返す可能性
+
+3. **apiRequest関数の引数不一致**
+   - 定義では3引数（method, url, options）
+   - 使用時は2引数（url, options）でmethodが欠落
+
+## リスク評価
+
+- **低リスク**: フロントエンド側の修正（影響範囲が限定的）
+- **中リスク**: 他のAPIエンドポイントへの影響（同様の問題が潜在的に存在）
+- **高リスク**: バックエンド側の修正（多くのクライアントに影響）
+
+## 検証項目
+
+1. カテゴリ取得APIが正しく動作すること
+2. 経費申請新規作成画面でカテゴリが表示されること
+3. カテゴリフィルタリングが正常に動作すること
+4. 他のAPIエンドポイントに影響がないこと
+
+## 推奨事項
+
+1. **即時対応**
+   - `getExpenseCategories`関数を修正（案2）
+   - 型定義を実際のレスポンス形式に合わせる
+
+2. **中期的対応**
+   - APIレスポンス形式の統一化を検討
+   - apiRequest関数の改修を検討
+   - 型定義の自動生成ツールの導入
+
+3. **予防策**
+   - APIレスポンスの型定義を厳密に管理
+   - エンドツーエンドテストの強化
+   - 開発時のネットワークレスポンス確認の徹底
+
+## 結論
+
+フロントエンドの`getExpenseCategories`関数がバックエンドのレスポンス形式（`{ data: [...] }`）を適切に処理していないことが原因。フロントエンド側で修正することで、最小限の変更で問題を解決できる。

--- a/docs/plan/plan_20250725_141000.md
+++ b/docs/plan/plan_20250725_141000.md
@@ -1,0 +1,229 @@
+# 経費申請新規作成画面のcategories.filterエラー修正実装計画
+
+## 計画日時
+2025-07-25 14:10:00
+
+## 調査結果参照
+`docs/investigate/investigate_20250725_140500.md`
+
+## 実装概要
+経費申請新規作成画面で発生している「TypeError: categories.filter is not a function」エラーを修正する。APIレスポンスの形式（`{ data: [...] }`）と期待される型（`ExpenseCategory[]`）の不一致を解消する。
+
+## 実装方針
+
+### 選択した解決策
+**`getExpenseCategories`関数の修正**を選択。理由：
+- 影響範囲が最小限（1関数のみ）
+- 型定義の整合性を保てる
+- 即座に問題を解決できる
+- 他のAPIエンドポイントに影響しない
+
+### 実装スコープ
+1. `getExpenseCategories`関数の修正
+2. 型定義の更新
+3. 関連する型チェックの確認
+4. ユニットテストの作成/更新
+5. E2Eテストの確認
+
+## 詳細実装タスク
+
+### Phase 1: コア機能の修正（必須）
+**優先度: Critical**
+1. **`getExpenseCategories`関数の修正**
+   - `/frontend/src/lib/api/expense.ts`
+   - レスポンスから`data`プロパティを適切に取り出す
+   - コード変更量：約5行
+
+### Phase 2: 型定義の整合性確保（必須）
+**優先度: High**
+1. **APIレスポンスの型定義作成**
+   - `ExpenseCategoryResponse`型の追加
+   - 実際のAPIレスポンス形式に合わせる
+
+2. **関連する型定義の確認**
+   - `ExpenseCategory`型の確認
+   - `is_active`と`isActive`のマッピング確認
+
+### Phase 3: テスト実装（必須）
+**優先度: High**
+1. **ユニットテストの作成/更新**
+   - `getExpenseCategories`関数のテスト
+   - モックレスポンスの更新
+
+2. **統合テストの確認**
+   - `useCategories`フックのテスト
+   - エラーケースのテスト追加
+
+### Phase 4: 動作確認（必須）
+**優先度: High**
+1. **ローカル環境での動作確認**
+   - 経費申請新規作成画面の表示
+   - カテゴリドロップダウンの動作
+   - カテゴリフィルタリングの確認
+
+2. **エラーハンドリングの確認**
+   - APIエラー時の動作
+   - 空のレスポンス時の動作
+
+### Phase 5: 他のAPIエンドポイントの確認（推奨）
+**優先度: Medium**
+1. **同様の問題の調査**
+   - 他の`apiRequest`使用箇所の確認
+   - レスポンス形式の統一性確認
+
+2. **共通化の検討**
+   - レスポンス処理の共通化
+   - 型定義の共通化
+
+## ファイル変更計画
+
+### 修正対象ファイル
+1. `/frontend/src/lib/api/expense.ts`
+   - `getExpenseCategories`関数の修正（約10行）
+   - 型定義の追加（約10行）
+
+### 新規作成ファイル
+なし
+
+### 削除対象ファイル
+なし
+
+## 実装詳細
+
+### 1. getExpenseCategories関数の修正
+```typescript
+// 修正前
+export async function getExpenseCategories(signal?: AbortSignal): Promise<ExpenseCategory[]> {
+  return apiRequest<ExpenseCategory[]>(EXPENSE_API_ENDPOINTS.CATEGORIES, { signal });
+}
+
+// 修正後
+interface ExpenseCategoryApiResponse {
+  data: Array<{
+    id: string;
+    code: string;
+    name: string;
+    requires_details: boolean;
+    is_active: boolean;
+    display_order: number;
+    created_at: string;
+    updated_at: string;
+  }>;
+}
+
+export async function getExpenseCategories(signal?: AbortSignal): Promise<ExpenseCategory[]> {
+  const response = await apiRequest<ExpenseCategoryApiResponse>(
+    EXPENSE_API_ENDPOINTS.CATEGORIES, 
+    { signal }
+  );
+  
+  // APIレスポンスをフロントエンドの型にマッピング
+  return response.data.map(category => ({
+    id: category.id,
+    code: category.code,
+    name: category.name,
+    requiresDetails: category.requires_details,
+    isActive: category.is_active,
+    displayOrder: category.display_order,
+    createdAt: category.created_at,
+    updatedAt: category.updated_at,
+  }));
+}
+```
+
+## テスト戦略
+
+### 単体テスト
+1. **APIレスポンスの処理**
+   - 正常なレスポンスの処理
+   - 空配列のレスポンス
+   - nullやundefinedの処理
+
+2. **型変換の確認**
+   - snake_caseからcamelCaseへの変換
+   - 各プロパティのマッピング
+
+### 統合テスト
+1. **useCategories フック**
+   - カテゴリ一覧の取得
+   - アクティブカテゴリのフィルタリング
+   - エラーハンドリング
+
+### E2Eテスト
+1. **経費申請画面**
+   - カテゴリドロップダウンの表示
+   - カテゴリ選択の動作
+   - フォーム送信の動作
+
+## リスク分析
+
+### 技術的リスク
+1. **低リスク**
+   - 単一関数の修正で影響範囲が限定的
+   - 型安全性が向上
+
+2. **中リスク**
+   - 他のAPIエンドポイントで同様の問題が潜在
+   - APIレスポンス形式の不統一
+
+### 対策
+1. **事前検証**
+   - 詳細なテストケースの実装
+   - 手動での動作確認
+
+2. **段階的な対応**
+   - まず緊急修正を実施
+   - その後、全体的な改善を検討
+
+## 実装スケジュール
+
+### 見積もり時間
+- Phase 1: 30分（コア機能の修正）
+- Phase 2: 30分（型定義の整合性確保）
+- Phase 3: 1時間（テスト実装）
+- Phase 4: 30分（動作確認）
+- Phase 5: 1時間（他のAPIエンドポイントの確認）
+
+**合計: 約3時間30分**
+
+### 実装順序
+1. Phase 1: 緊急修正
+2. Phase 2: 型定義の更新
+3. Phase 4: 簡易動作確認
+4. Phase 3: テスト実装
+5. Phase 5: 全体的な改善検討
+
+## 成功基準
+
+1. **機能要件**
+   - 経費申請新規作成画面でエラーが発生しない
+   - カテゴリドロップダウンが正常に表示される
+   - カテゴリ選択が可能
+
+2. **非機能要件**
+   - TypeScriptの型チェックが通る
+   - 既存のテストが全て成功
+   - パフォーマンスの劣化なし
+
+## 備考
+
+### APIレスポンス形式の統一について
+現在、バックエンドAPIは`{ data: [...] }`形式でレスポンスを返していますが、フロントエンドの期待と異なっています。将来的には以下の対応を検討：
+
+1. **APIレスポンス形式の標準化**
+   - 全エンドポイントで統一された形式
+   - エラーレスポンスの標準化
+
+2. **APIクライアントの改善**
+   - 共通のレスポンス処理
+   - 自動的な型変換
+
+3. **型定義の自動生成**
+   - OpenAPIスキーマからの生成
+   - バックエンドとの型同期
+
+### ローカルapiRequest関数について
+`expense.ts`内にローカルな`apiRequest`関数が定義されており、グローバルな`apiRequest`関数とシグネチャが異なる。将来的には統一を検討。
+
+## 結論
+最小限の変更で即座に問題を解決し、その後段階的に全体的な改善を進める方針。型安全性を保ちながら、実装の影響を最小限に抑える。

--- a/frontend/src/lib/api/expense.ts
+++ b/frontend/src/lib/api/expense.ts
@@ -316,9 +316,36 @@ export async function deleteReceipt(expenseId: string, receiptUrl: string): Prom
   });
 }
 
+// 経費カテゴリAPIレスポンスの型定義
+interface ExpenseCategoryApiResponse {
+  data: Array<{
+    id: string;
+    code: string;
+    name: string;
+    requires_details: boolean;
+    is_active: boolean;
+    display_order: number;
+    created_at: string;
+    updated_at: string;
+  }>;
+}
+
 // 経費カテゴリ一覧を取得
 export async function getExpenseCategories(signal?: AbortSignal): Promise<ExpenseCategory[]> {
-  return apiRequest<ExpenseCategory[]>(EXPENSE_API_ENDPOINTS.CATEGORIES, { signal });
+  const response = await apiRequest<ExpenseCategoryApiResponse>(
+    EXPENSE_API_ENDPOINTS.CATEGORIES, 
+    { signal }
+  );
+  
+  // APIレスポンスをフロントエンドの型にマッピング
+  return response.data.map(category => ({
+    id: category.id,
+    name: category.name,
+    displayOrder: category.display_order,
+    isActive: category.is_active,
+    createdAt: category.created_at,
+    updatedAt: category.updated_at,
+  }));
 }
 
 // 経費レポートを生成


### PR DESCRIPTION
## Summary
- 経費申請新規作成画面で発生していた「TypeError: categories.filter is not a function」エラーを修正
- APIレスポンスが`{ data: [...] }`形式で返されるが、フロントエンドが配列を期待していたため、適切にデータを展開するように修正

## 背景
経費申請の新規作成画面でカテゴリを取得する際に、以下のエラーが発生していました：
```
TypeError: categories.filter is not a function
    at useCategories.useMemo[activeCategories] (useCategories.ts:91:23)
```

調査の結果、バックエンドAPIが`{ data: [...] }`形式でレスポンスを返しているが、フロントエンドの`getExpenseCategories`関数が配列を直接返すことを期待していたことが原因と判明。

## 変更内容
1. **型定義の追加**
   - `ExpenseCategoryApiResponse`インターフェースを追加し、実際のAPIレスポンス形式を定義

2. **getExpenseCategories関数の修正**
   - `response.data`を展開して配列を返すように修正
   - snake_caseのAPIレスポンスをcamelCaseにマッピング

## Test plan
- [ ] 経費申請新規作成画面でエラーが発生しないことを確認
- [ ] カテゴリドロップダウンが正常に表示されることを確認
- [ ] カテゴリの選択が可能であることを確認
- [ ] TypeScriptの型チェックが通ることを確認

## 関連ドキュメント
- 調査結果: `docs/investigate/investigate_20250725_140500.md`
- 実装計画: `docs/plan/plan_20250725_141000.md`

🤖 Generated with [Claude Code](https://claude.ai/code)