### PR TITLE
ci(e2e): set DOCKER_DEFAULT_PLATFORM=linux/amd64

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -15,6 +15,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      DOCKER_DEFAULT_PLATFORM: linux/amd64
 
     steps:
       - name: Checkout
@@ -35,6 +37,7 @@ jobs:
         env:
           # Backend settings for CI (disable Cognito to avoid external deps)
           COGNITO_ENABLED: "false"
+          DOCKER_DEFAULT_PLATFORM: linux/amd64
         run: |
           docker compose up -d postgres redis minio
           # wait for minio-setup to complete

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,6 +25,8 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      DOCKER_DEFAULT_PLATFORM: linux/amd64
     
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- Force amd64 platform in e2e workflows on GitHub-hosted runners to avoid exec format errors.

## Rationale
- Runners are amd64; our docker images/steps were hitting architecture mismatches when building/starting the stack.

## Scope of Changes
- `.github/workflows/e2e-playwright.yml`
- `.github/workflows/e2e-tests.yml`

## Notes
- See docs/pr-guidelines.md for PR requirements.

## Checklist
- [x] docs/pr-guidelines.md を読み、内容に準拠しています
- [x] 変更範囲は最小で、不要な差分を含みません
- [x] 命名・責務・エラーハンドリング・ログ方針が一貫しています
- [x] テストを追加/更新し、ローカルで通過しています（必要箇所）
- [x] CIが通過しています（再実行含む)
